### PR TITLE
Solve `memoverride.cpp` failing to override all versions of `new/new[]/delete/delete[]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,6 @@ config.cfg
 
 mp/game
 
-
+# In case you mklink/symlink vphysics_jolt or just build it inside of here directly
+gmod/game/bin/**
+gmod/src/vphysics_jolt

--- a/gmod/src/public/tier0/memoverride.cpp
+++ b/gmod/src/public/tier0/memoverride.cpp
@@ -465,6 +465,54 @@ void __cdecl operator delete[] ( void *pMem ) throw()
 }
 #endif
 
+// RaphaelIT7: due to __cpp_aligned_new which exists seamingly from C++17 & higher
+// we need to override these too as else we might try to delete unaligned memory as aligned memory!
+
+void *__cdecl operator new( size_t nSize, std::align_val_t align )
+{
+	return AllocUnattributed( nSize );
+}
+
+void *__cdecl operator new[] ( size_t nSize, std::align_val_t align )
+{
+	return AllocUnattributed( nSize );
+}
+
+void operator delete( void* pMem, std::align_val_t align ) noexcept
+{
+#if !defined(USE_LIGHT_MEM_DEBUG) && !defined(USE_MEM_DEBUG)
+	g_pMemAlloc->Free( pMem );
+#else
+	g_pMemAlloc->Free( pMem, ::g_pszModule, 0 );
+#endif
+}
+
+void operator delete[]( void* pMem, std::align_val_t align ) noexcept
+{
+#if !defined(USE_LIGHT_MEM_DEBUG) && !defined(USE_MEM_DEBUG)
+	g_pMemAlloc->Free( pMem );
+#else
+	g_pMemAlloc->Free( pMem, ::g_pszModule, 0 );
+#endif
+}
+
+void operator delete( void* pMem, size_t sz, std::align_val_t align ) noexcept
+{
+#if !defined(USE_LIGHT_MEM_DEBUG) && !defined(USE_MEM_DEBUG)
+	g_pMemAlloc->Free( pMem );
+#else
+	g_pMemAlloc->Free( pMem, ::g_pszModule, 0 );
+#endif
+}
+
+void operator delete[]( void* pMem, size_t sz, std::align_val_t align ) noexcept
+{
+#if !defined(USE_LIGHT_MEM_DEBUG) && !defined(USE_MEM_DEBUG)
+	g_pMemAlloc->Free( pMem );
+#else
+	g_pMemAlloc->Free( pMem, ::g_pszModule, 0 );
+#endif
+}
 
 //-----------------------------------------------------------------------------
 // Override some debugging allocation methods in MSVC


### PR DESCRIPTION
This is a fun one - Solves https://github.com/misyltoad/VPhysics-Jolt/issues/259

Example of this issue:
`JPH::Ref<JPH::CharacterSettings> settings = new JPH::CharacterSettings();`
in this line it internally allocates the memory using `g_pMemAlloc->Alloc` since memoverride overwrote `new`
Now, when the `JPH::Ref` leaves the scope / gets released, it calls `delete static_cast<const T *>(this);`
The issue with that is, that in C++17 & higher there is `__cpp_aligned_new` which introduces more versions of `new`, `new[]`, `delete`, `delete[]`
which are all not accounted for leaving them in a weird state where they might call the memoverride version - or they call the C++ standart version which ends up trying to delete the memory as aligned memory.
And for this example case it tries to call `void operator delete( void* pMem, size_t sz, std::align_val_t align ) noexcept` which was not overwritten.